### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,8 +20,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: |
-            npm i -g gatsby
+        run: npm ci
 
       - name: Release Package
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,10 +20,8 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm ci
-
-      - name: Create Build
-        run: npm run build
+        run: |
+            npm i -g gatsby
 
       - name: Release Package
         env:


### PR DESCRIPTION
During Migration from travis to GitHub CI in this [PR](https://github.com/edx/gatsby-source-portal-designer/commit/261d76753fe59760f57757d47ddadada417c8390), build step was added to release workflow which does not exist in package.json and hence is causing the release to fail. This PR fixes the Issue with the release workflow