### PR TITLE
fix: remove useless schema element from Graphql typesdef

### DIFF
--- a/schema/types.gql
+++ b/schema/types.gql
@@ -1,8 +1,4 @@
 module.exports = `
-  schema {
-    query: Query
-  }
-
   type Query{
     page: [page]
   }


### PR DESCRIPTION
The `schema` element within types.gql is no longer necessary and causes error during Gatsby bootstrap process.
Remove it so we can upgrade gatsby version