### PR TITLE
chore: update github npm publish workflow to run on release publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,8 +1,7 @@
 name: Release CI
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
Currently, the github npm package publish workflow runs on git push, but not running from master branch.
I am configuring this repo to run from release number publish

@aht007 Please be aware.