### PR TITLE
fix: update release process to run from main

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,7 +1,8 @@
 name: Release CI
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
The last PR on running NPM release still didn't work. Want to do release from master branch instead.